### PR TITLE
Feat/srv discovery retry

### DIFF
--- a/tests/test_etcd3.py
+++ b/tests/test_etcd3.py
@@ -1186,7 +1186,8 @@ class TestClient(object):
             cert_key="tests/client.key",
             cert_cert="tests/client.crt"
         )
-        assert client.uses_secure_channel is True
+        assert len(client.endpoints) > 0
+        assert all([c.secure for c in client.endpoints.values()])
 
     def test_secure_channel_ca_cert_only(self):
         client = etcd3.client(
@@ -1194,7 +1195,8 @@ class TestClient(object):
             cert_key=None,
             cert_cert=None
         )
-        assert client.uses_secure_channel is True
+        assert len(client.endpoints) > 0
+        assert all([c.secure for c in client.endpoints.values()])
 
     def test_secure_channel_ca_cert_and_key_raise_exception(self):
         with pytest.raises(ValueError):
@@ -1220,7 +1222,8 @@ class TestClient(object):
             cert_key=None,
             cert_cert=None
         )
-        assert client.uses_secure_channel is False
+        assert len(client.endpoints) > 0
+        assert all([not c.secure for c in client.endpoints.values()])
 
     @mock.patch('etcdrpc.AuthStub')
     def test_user_pwd_auth(self, auth_mock):

--- a/tests/test_etcd3.py
+++ b/tests/test_etcd3.py
@@ -1429,12 +1429,12 @@ class TestSRVDiscoveryClient(object):
             with etcd3.SRVDiscoveryEtcd3Client(srv=srv_record) as client:
                 assert resolve_mock.call_count == 1
                 assert len(client.endpoints) == 1
-                endpoint = list(client.endpoints.values())[0]
-                assert str(endpoint) == "Endpoint({})".format(etcd_endpoint)
+                actual_endpoint = list(client.endpoints.values())[0]
+                assert endpoint.netloc == actual_endpoint.netloc
 
                 client.refresh_endpoints()
 
                 assert resolve_mock.call_count == 2
                 assert len(client.endpoints) == 1
-                endpoint = list(client.endpoints.values())[0]
-                assert str(endpoint) == "Endpoint(http://fake:2379)"
+                actual_endpoint = list(client.endpoints.values())[0]
+                assert fake_endpoint.netloc == actual_endpoint.netloc


### PR DESCRIPTION
feat: implement periodic resolution of SRV records to refresh list of endpoints

Some unrelated cleanup:
chore: fix unit tests involving removed use_secure_channel attribute
chore: fix refresh_endpoints unit tests